### PR TITLE
provide++

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -8,23 +8,32 @@
 ;; and 'main.rkt' will just be the library's API.
 
 (provide
- def
- ;replace 'provide' with a form that requires a doc and a contract
- ;macros for easy list access (to replace vector-ref, etc)
+ provide/api
+ ;; (provide (ID CONTRACT DOC) ...)
+ ;; An optional `provide` form for identifiers that requires a contract and
+ ;;  docstring. Desugars to a `contract-out` for the identifier.
+ (all-from-out racket/contract)
+ ;; Re-export `racket/contract`, for `provide/api` to work.
 )
 
 ;; -----------------------------------------------------------------------------
 
 (require
+ racket/contract
  (for-syntax
   racket/base
-  syntax/parse))
+  syntax/parse
+  (only-in unstable/sequence in-syntax)))
 
 ;; =============================================================================
 
-;; Sample macro, to make sure package install worked
-(define-syntax (def stx)
+(define-syntax (provide/api stx)
   (syntax-parse stx
-    [(_ x:id e)
-     (printf "MACRO WORKED\n")
-     #'(define x e)]))
+    [(_ (~seq pr*:id
+              #:contract ctr*
+              #:doc      doc*:str) ...)
+     ;; Ignores the docstring for now.
+     ;;  should check if compiling in documentation mode & save doc.
+     ;; Also, a "no contract" form/flag would be nice.
+     #'(provide (contract-out [pr* ctr*] ...))]
+    [_ (error (format "provide/api: syntax error, expected '(provide/api (ID CONTRACT DOC) ...)' but given '~a'" (syntax->datum stx)))]))


### PR DESCRIPTION
Alternate provide form. Requires a contract and documentation. Only works for identifiers.

Sample:

```
(provide/api
  square
  #:contract (-> number? number?)
  #:doc "`(square n)` computes `n^2`"
  pad
  #:contract (->* [string? natural?] [#:fill-char char?] string?)
  #:doc "`(pad str n #:fill-char c)` creates a string of length `n` whose first
    characters match `str` and remaining characters are duplicates of `c`.
    By default, `#:fill-char` is `#\space`"
)
```

To discuss:
- [x] do we like the choice of keywords? Want to change, or add options?
- [x] do we like the order of keywords, or should that be flexible
- [x] okay to include all of `racket/contract` when requiring `mechanics`?
- [x] need to `provide/api` more than just identifiers? (We can always still `provide` in a file.)

Lower priority (create issues for these)
- [ ] pick a syntax for disabling contacts
- [ ] decide how / where to compile documentation
- [ ] create a "docstring" language (or syntax class)
