### PR TITLE
#lang mechanics

### DIFF
--- a/lang/main.rkt
+++ b/lang/main.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(require mechanics)
+
+(provide
+  (all-from-out racket/base)
+  (all-from-out mechanics))

--- a/lang/reader.rkt
+++ b/lang/reader.rkt
@@ -1,0 +1,2 @@
+#lang s-exp syntax/module-reader
+mechanics/lang/main

--- a/private/kernel/interval.rkt
+++ b/private/kernel/interval.rkt
@@ -1,4 +1,4 @@
-#lang racket/base
+#lang mechanics
 
 ;; Utilities for working with subsets of the real line.
 ;; Alternatively, for representing data points that have a tolerance.
@@ -11,7 +11,6 @@
 ;;   (arranged from lowest lo bound upward, all intervals disjoint)
 
 (require
-  mechanics
   (for-syntax racket/base syntax/parse)
   (only-in racket/match match-define)
 )

--- a/private/kernel/vector.rkt
+++ b/private/kernel/vector.rkt
@@ -1,4 +1,4 @@
-#lang racket/base
+#lang mechanics
 
 ;; Vector functions missing from racket & racket/math
 

--- a/private/numerics/functions/bessel.rkt
+++ b/private/numerics/functions/bessel.rkt
@@ -1,7 +1,6 @@
-#lang racket/base
+#lang mechanics
 
 ;; This module defines the bessel functions of integer order
-(require racket/contract/base)
 (provide
  (contract-out
   [bessj₀ (-> number? number?)]
@@ -13,14 +12,6 @@
   [bessh₀ (-> number? complex?)]
   [bessh₁ (-> number? complex?)]
   [bessh  (-> integer? number? complex?)]))
-
-(require
- (only-in mechanics
-          π
-          π/4
-          π/2
-          3π/4
-          2/π))
 
 (require
  (only-in math/number-theory factorial))

--- a/private/numerics/functions/bessjs.rkt
+++ b/private/numerics/functions/bessjs.rkt
@@ -1,4 +1,4 @@
-#lang racket/base
+#lang mechanics
 
 ;;;; Bessel Functions:
 
@@ -10,7 +10,6 @@
 ;;;    ( J0(x) ... Jn(x) ) 
 ;;;   that is good to machine precision for x < 2 and large n.
 
-(require racket/contract/base)
 (provide
  (contract-out
   [bessjs (-> exact-nonnegative-integer? positive? (listof number?))]))
@@ -67,7 +66,6 @@
 (module+ test
   (require rackunit
            rackunit/text-ui
-           (only-in mechanics π/2 π 3π/2 2π)
            math/matrix
            (only-in racket/vector vector-map)
            (only-in racket/format ~a)

--- a/private/numerics/functions/elliptic-flo.rkt
+++ b/private/numerics/functions/elliptic-flo.rkt
@@ -1,6 +1,4 @@
-#lang racket/base
-
-(require racket/contract/base)
+#lang mechanics
 
 (provide
  (contract-out
@@ -20,8 +18,6 @@
           flsqrt
           fl*
           fl-))
-
-(require (only-in mechanics π π/2 *machine-ε*))
 
 (define (first-elliptic-integral k)
   (let loop ([a 1.0]

--- a/private/numerics/functions/elliptic.rkt
+++ b/private/numerics/functions/elliptic.rkt
@@ -1,4 +1,4 @@
-#lang racket/base
+#lang mechanics
 
 ;; Consult "Numerical Computation of Real or Complex Elliptic
 ;; Integrals" Carlson (1994) http://arxiv.org/pdf/math/9409227v1.pdf
@@ -8,7 +8,6 @@
 ;;
 ;; Consider also exporting under the more familiar names Rf, Rj, Rc,
 ;; Rd. Is there any input method that gets those names as subscripts.
-(require racket/contract/base)
 (provide
  (contract-out
   ;; Carlson elliptic integrals R_F
@@ -72,12 +71,7 @@
       number?))
 
 (require
- (only-in mechanics π π/2 square *machine-ε*))
-
-(require
- (only-in racket/math cosh tanh))
-
-(require
+ (only-in racket/math cosh tanh)
  (only-in racket/fixnum fx< fx+))
 
 (define (Rf x y z)
@@ -307,8 +301,7 @@
 
 (module+ test
   (require rackunit
-           rackunit/text-ui
-           (only-in mechanics π/2))
+           rackunit/text-ui)
 
   (define test-suite-ε 1e-7)
   (run-tests

--- a/private/numerics/integer/continued-fractions.rkt
+++ b/private/numerics/integer/continued-fractions.rkt
@@ -1,9 +1,8 @@
-#lang racket/base
+#lang mechanics
 
 ;; Continued Fractions stream approximations of real numbers.
 ;; http://en.wikipedia.org/wiki/Continued_fraction
 
-(require mechanics)
 (provide/api
  continued-fraction
  #:contract (-> real? (sequenceof integer?))

--- a/private/numerics/integer/farey.rkt
+++ b/private/numerics/integer/farey.rkt
@@ -1,4 +1,4 @@
-#lang racket/base
+#lang mechanics
 
 ;; Farey Trees (aka Stern-Brocot Trees)
 ;; http://mathworld.wolfram.com/FareySequence.html
@@ -10,7 +10,6 @@
 ;; Because the mediants are always between the given fractions
 ;; the levels are ordered if the first one is ordered.
 
-(require mechanics)
 (provide/api
   farey
   #:contract (-> natural? natural? (-> natural? (listof exact-rational?)))


### PR DESCRIPTION
Instead of doing

```
#lang racket/base
(require mechanics)
```

We can now do

```
#lang mechanics
```

Fixes #27 .
Thanks [stackoverflow](http://stackoverflow.com/questions/33933394/use-a-library-as-a-lang)!
